### PR TITLE
Added frequency of each blast results to the sample composition table

### DIFF
--- a/rules/blast.smk
+++ b/rules/blast.smk
@@ -12,10 +12,20 @@ def get_mask():
         return "common/taxid_mask.txt"
 
 def concatenate_uniq(entries):
-    s = str(entries.to_list()[0])
-    uniq = list(set(s.split("; ")))
-    uniq_no_zero = ["-" if e=="0" else e for e in uniq]
-    return "; ".join(uniq_no_zero)
+    s = "; ".join(entries.to_list())
+    df = pd.DataFrame([e.rsplit(' (', 1) for e in s.split("; ")], columns=["name", "freq"]) #parenthesis in names
+    df['freq'] = df['freq'].str.replace(')', '').astype(float)
+
+    # Aggreagte, normalize, and sort
+    tot = df['freq'].sum()
+    df = df.groupby("name").apply(lambda x: x.sum()/tot)
+    df = df.sort_values(by = ["freq"], ascending = False)
+    
+    # Format as string
+    uniq = df.to_dict()['freq']
+    uniq = [f"{name} ({round(freq, 2)})" for name, freq in uniq.items()]
+    
+    return "; ".join(uniq)
 
 #  Rules DB Masking ------------------------------------------------------------
 


### PR DESCRIPTION
Adds information about how often each balst result was found for a given consensus taxonomic assignement.
Can be used to identify dubious consensus or high ranks with little support.
